### PR TITLE
plat-131-upgrade-node-in-actions

### DIFF
--- a/composite/deploy-cdk/action.yaml
+++ b/composite/deploy-cdk/action.yaml
@@ -67,7 +67,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v6

--- a/composite/setup-node/action.yaml
+++ b/composite/setup-node/action.yaml
@@ -6,7 +6,7 @@ inputs:
   node_version:
     description: Node version
     required: false
-    default: '22'
+    default: '24'
 
   machine_user_pat:
     description: Github Catena Machine User Personal Access Token (PAT)


### PR DESCRIPTION
Upgrade the Node version used in actions. The current one is set to 20, which is deprecated, causing warnings like the following, by CDK.

```
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
b'!!                                                                                                                   !!\n'
b'!!  Node 20 has reached end-of-life on 2026-04-30 and will no longer be supported in new releases after 2026-10-30.  !!\n'
b'!!  Please upgrade to a supported node version as soon as possible.                                                  !!\n'
b'!!                                                                                                                   !!\n'
b'!!  This software is currently running on node v20.20.2.                                                             !!\n'
b'!!  As of the current release of this software, supported node releases are:                                         !!\n'
b'!!  - ^24.0.0 (Planned end-of-life: 2028-04-30)                                                                      !!\n'
b'!!  - ^22.0.0 (Planned end-of-life: 2027-04-30)                                                                      !!\n'
b'!!  - ^20.0.0 (Planned end-of-life: 2026-04-30) [DEPRECATED]                                                         !!\n'
b'!!                                                                                                                   !!\n'
b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION environment variable.   !!\n'
b'!!                                                                                                                   !!\n'
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
```