### PR TITLE
[PLAT-247] Guard deploy-cdk against stack-name collisions

### DIFF
--- a/composite/deploy-cdk/action.yaml
+++ b/composite/deploy-cdk/action.yaml
@@ -85,7 +85,10 @@ runs:
         if STACK_JSON=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --output json 2>/dev/null); then
           OWNER=$(echo "$STACK_JSON" | jq -r --arg k "$OWNER_TAG" 'first(.Stacks[0].Tags[]? | select(.Key == $k) | .Value) // ""')
           if [ -n "$OWNER" ] && [ "$OWNER" != "$THIS_REPO" ]; then
-            echo "::error::Stack '$STACK_NAME' already exists and is owned by repo '$OWNER' (tag $OWNER_TAG). Refusing to deploy from '$THIS_REPO' — this would overwrite another service's stack. Choose a unique stack name in app.py and deploy.yaml."
+            MSG="Stack '$STACK_NAME' already exists and is owned by repo '$OWNER' (tag $OWNER_TAG)."
+            MSG="$MSG Refusing to deploy from '$THIS_REPO' - this would overwrite another service's stack."
+            MSG="$MSG Choose a unique stack name in app.py and deploy.yaml."
+            echo "::error::$MSG"
             exit 1
           fi
           if [ -z "$OWNER" ]; then

--- a/composite/deploy-cdk/action.yaml
+++ b/composite/deploy-cdk/action.yaml
@@ -76,6 +76,30 @@ runs:
         role-session-name: ${{ github.event.repository.name }}-${{ github.actor }}
         aws-region: ${{ inputs.aws_region }}
 
+    - name: Guard against stack-name collision
+      shell: bash
+      run: |
+        set -euo pipefail
+        OWNER_TAG="cost:repo"
+        THIS_REPO="${GITHUB_REPOSITORY##*/}"
+        if STACK_JSON=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --output json 2>/dev/null); then
+          OWNER=$(echo "$STACK_JSON" | jq -r --arg k "$OWNER_TAG" 'first(.Stacks[0].Tags[]? | select(.Key == $k) | .Value) // ""')
+          if [ -n "$OWNER" ] && [ "$OWNER" != "$THIS_REPO" ]; then
+            echo "::error::Stack '$STACK_NAME' already exists and is owned by repo '$OWNER' (tag $OWNER_TAG). Refusing to deploy from '$THIS_REPO' — this would overwrite another service's stack. Choose a unique stack name in app.py and deploy.yaml."
+            exit 1
+          fi
+          if [ -z "$OWNER" ]; then
+            echo "::warning::Stack '$STACK_NAME' exists but has no '$OWNER_TAG' tag, so ownership can't be verified. Proceeding."
+          else
+            echo "Stack '$STACK_NAME' is owned by '$OWNER' (this repo). Safe to update."
+          fi
+        else
+          echo "Stack '$STACK_NAME' does not exist yet. Safe to create."
+        fi
+      env:
+        STACK_NAME: ${{ inputs.stack_name }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+
     - name: CDK Deploy
       shell: bash
       run: |

--- a/composite/deploy-cdk/action.yaml
+++ b/composite/deploy-cdk/action.yaml
@@ -80,28 +80,44 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        cd "$DIRECTORY"
+        source .venv/bin/activate
         OWNER_TAG="cost:repo"
-        THIS_REPO="${GITHUB_REPOSITORY##*/}"
+        # Owner value this deploy would apply, read from the synthesized template so we
+        # compare like-for-like against the deployed stack's own tag. We deliberately do
+        # NOT use the repo name: cost:repo is not guaranteed to equal the repo (e.g.
+        # catena-dashboard tags cost:repo=telematics-dashboard-service), so comparing to
+        # the repo name would falsely block that service from deploying to its own stack.
+        npx -y "aws-cdk@$CDK_VERSION" synth "$STACK_NAME" --quiet --output .cdk-guard-out
+        TEMPLATE=".cdk-guard-out/$STACK_NAME.template.json"
+        MINE=$(jq -r --arg k "$OWNER_TAG" 'first(.. | objects | select(.Key? == $k) | .Value) // ""' "$TEMPLATE")
+        if [ -z "$MINE" ]; then
+          echo "::warning::Could not read '$OWNER_TAG' from the synthesized template; skipping ownership check."
+          exit 0
+        fi
         if STACK_JSON=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --output json 2>/dev/null); then
           OWNER=$(echo "$STACK_JSON" | jq -r --arg k "$OWNER_TAG" 'first(.Stacks[0].Tags[]? | select(.Key == $k) | .Value) // ""')
-          if [ -n "$OWNER" ] && [ "$OWNER" != "$THIS_REPO" ]; then
-            MSG="Stack '$STACK_NAME' already exists and is owned by repo '$OWNER' (tag $OWNER_TAG)."
-            MSG="$MSG Refusing to deploy from '$THIS_REPO' - this would overwrite another service's stack."
+          if [ -z "$OWNER" ]; then
+            echo "::warning::Stack '$STACK_NAME' exists but has no '$OWNER_TAG' tag; cannot verify ownership. Proceeding."
+          elif [ "$OWNER" != "$MINE" ]; then
+            MSG="Stack '$STACK_NAME' already exists and is owned by '$OWNER' (tag $OWNER_TAG)."
+            MSG="$MSG This deploy is owned by '$MINE' - refusing to overwrite another service's stack."
             MSG="$MSG Choose a unique stack name in app.py and deploy.yaml."
             echo "::error::$MSG"
             exit 1
-          fi
-          if [ -z "$OWNER" ]; then
-            echo "::warning::Stack '$STACK_NAME' exists but has no '$OWNER_TAG' tag, so ownership can't be verified. Proceeding."
           else
-            echo "Stack '$STACK_NAME' is owned by '$OWNER' (this repo). Safe to update."
+            echo "Stack '$STACK_NAME' is owned by '$OWNER' (matches this deploy). Safe to update."
           fi
         else
           echo "Stack '$STACK_NAME' does not exist yet. Safe to create."
         fi
       env:
         STACK_NAME: ${{ inputs.stack_name }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
+        DIRECTORY: ${{ inputs.directory }}
+        CDK_VERSION: ${{ inputs.cdk_version }}
+        GITHUB_TOKEN: ${{ inputs.machine_user_pat }}
+        DOCKER_BUILDKIT: 1
+        BUILDX_BUILDER: ${{ steps.buildx.outputs.name }}
 
     - name: CDK Deploy
       shell: bash


### PR DESCRIPTION
## What
Adds a pre-deploy **ownership guard** to `composite/deploy-cdk/action.yaml`. Right after AWS credentials are configured and before `cdk deploy`, it describes the target CloudFormation stack; if the stack already exists and its `cost:repo` tag belongs to a **different** repo, the deploy fails instead of silently overwriting another service's stack.

## Why
A new service (`catena-dashboard-service`) synthesized a stack named `Dashboard-Production` — already owned by `catena-dashboard` — and `cdk deploy --force` updated the existing stack in place, taking the other service down. See PLAT-247.

## Behavior (fail-safe)
- Stack doesn't exist -> proceed (new stack).
- Stack exists, `cost:repo` == this repo -> proceed (normal update).
- Stack exists, `cost:repo` == **other** repo -> **fail** with a clear error.
- Stack exists but has no `cost:repo` tag -> warn and proceed (avoids false blocks on legacy stacks).

## Rollout
Consumers pin `@v0`. This PR does **not** move the tag. After merge, re-tag `v0` to this commit; every service then picks up the guard on its next deploy run (not retroactive to past deploys).

Linear: PLAT-247