### PR TITLE
fix(plat-256): bump actions/checkout to v7

### DIFF
--- a/.github/workflows/sast-scheduled.yaml
+++ b/.github/workflows/sast-scheduled.yaml
@@ -17,7 +17,7 @@ jobs:
     name: SAST (Semgrep)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: SAST (Semgrep)
         uses: ./composite/sast-semgrep

--- a/.github/workflows/status-checks.yaml
+++ b/.github/workflows/status-checks.yaml
@@ -20,7 +20,7 @@ jobs:
       group: lint-${{ github.workflow }}-${{ github.actor }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Lint
         uses: catenaclearing/catena-actions/composite/lint-python@main
@@ -34,7 +34,7 @@ jobs:
       group: test-${{ github.workflow }}-${{ github.actor }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
       group: checkov-${{ github.workflow }}-${{ github.actor }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Checkov
         uses: catenaclearing/catena-actions/composite/checkov@main
@@ -64,7 +64,7 @@ jobs:
       group: semgrep-${{ github.workflow }}-${{ github.actor }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: SAST (Semgrep)
         uses: ./composite/sast-semgrep

--- a/composite/open-pull-request/action.yaml
+++ b/composite/open-pull-request/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Create Pull Request
       shell: bash

--- a/composite/release-protected-branch/action.yaml
+++ b/composite/release-protected-branch/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Temporarily disable "include administrators" branch protection
       uses: benjefferies/branch-protection-bot@v1


### PR DESCRIPTION
Bumps actions/checkout v6 -> v7 (node20 -> node24 runtime, security hardening) across CI workflows and the open-pull-request / release-protected-branch composites. Uniform with the plat-256 checkout hardening.