### PR TITLE
fix(sast-semgrep): bump actions/upload-artifact v4 → v6 (Node 20 deprecation)

### DIFF
--- a/composite/sast-semgrep/action.yaml
+++ b/composite/sast-semgrep/action.yaml
@@ -134,7 +134,7 @@ runs:
 
     - name: Upload Semgrep results (evidence artifact)
       if: ${{ always() && inputs.upload_artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.artifact_name }}
         path: |


### PR DESCRIPTION
## What?

Bumps `actions/upload-artifact@v4` → `@v6` in the `sast-semgrep` composite action.

## Why?

`actions/upload-artifact@v4` runs on the **deprecated Node.js 20 runtime**, which GitHub is currently forcing onto Node 24 and will remove:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

`v6` targets Node 24 natively and matches the other actions already pinned in this repo (`checkout@v6`, `cache@v5`, `setup-node@v6`, `setup-python@v6`). The inputs used here (`name` / `path` / `retention-days`) are unchanged across the bump — no breaking change.

## Scope / impact

This was the **only** action still on a Node-20 (`@v4`) pin in `catena-actions`. Every consuming repo references this composite via the moving `catenaclearing/catena-actions/composite/sast-semgrep@v0` tag, so:

- [ ] After merge, **move the `v0` (and `latest`) tag** to the new commit via the normal release flow, so consumers pick up the fix and the deprecation warning clears across all repos' SAST runs.

Note: `semgrep.yml` (standalone template) and the `mastery-control-evidence` snapshot copy still contain `@v4` — the template can be bumped separately if still maintained; the evidence copy is an audit snapshot and should refresh on next collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)